### PR TITLE
Fix "prequ check --silent" to really be silent

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,11 @@ Features
 
 - Detect annotation and other options from the existing output files
 
+Bug Fixes
+~~~~~~~~~
+
+- Fix "prequ check --silent" not being silent on outdated txt files
+
 1.1.0
 -----
 

--- a/prequ/scripts/compile.py
+++ b/prequ/scripts/compile.py
@@ -24,7 +24,8 @@ def main(ctx, verbose, silent, check):
     try:
         compile(ctx, verbose, silent, check)
     except PrequError as error:
-        log.error('{}'.format(error))
+        if not check or not silent:
+            log.error('{}'.format(error))
         raise SystemExit(1)
 
 


### PR DESCRIPTION
The "--silent" option to "prequ check" command should make it to not
generate any output, except in errors.  A requirement*.txt file being
outdated is not an error, but just something that should be reported via
the exit code when being silent.

Make the check command not output "requirement*.txt is outdated" when
ran with the silent flag, but rather just set the non-zero exit code.