### PR TITLE
Implement "prequ check --verbose"

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,7 @@ Features
 
 - Detect annotation and other options from the existing output files
 - Merge configuration from setup.cfg with requirements*.in files
+- Add "prequ check --verbose" for showing what is outdated
 
 Bug Fixes
 ~~~~~~~~~

--- a/prequ/scripts/check.py
+++ b/prequ/scripts/check.py
@@ -2,13 +2,16 @@ import click
 
 from . import build_wheels, compile
 
+click.disable_unicode_literals_warning = True
+
 
 @click.command()
+@click.option('-v', '--verbose', is_flag=True, help="Show more output")
 @click.option('-s', '--silent', is_flag=True, help="Show no output")
 @click.pass_context
-def main(ctx, silent):
+def main(ctx, verbose, silent):
     """
     Check if generated requirements are up-to-date.
     """
     ctx.invoke(build_wheels.main, check=True, silent=silent)
-    ctx.invoke(compile.main, check=True, silent=silent)
+    ctx.invoke(compile.main, check=True, verbose=verbose, silent=silent)


### PR DESCRIPTION
Add a verbose option for "prequ check" command to make it easier to spot
which requirements are outdated in the txt file.

With verbose option being on the command prints diff of the current and
expected txt file contents.