### PR TITLE
Bug fix: Follow only dependencies of current platform

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+Unreleased
+----------
+
+Bug Fixes
+~~~~~~~~~
+
+- Correctly follow only the dependencies of the current platform
+
 1.2.0
 -----
 
@@ -47,7 +55,6 @@ Bug Fixes
 - Prevent conflicting package versions as expeceted.  The resolver used
   to allow selecting a pinned version V for a package P1 even though
   another package P2 required a version of P1 that is not V.
-
 
 1.0.1
 -----

--- a/prequ/repositories/pypi.py
+++ b/prequ/repositories/pypi.py
@@ -10,7 +10,6 @@ from shutil import rmtree
 from pip.download import is_file_url, url_to_path
 from pip.index import PackageFinder
 from pip.req.req_set import RequirementSet
-from pip.wheel import Wheel
 
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound
@@ -29,24 +28,6 @@ try:
     from tempfile import TemporaryDirectory  # added in 3.2
 except ImportError:
     from .._compat import TemporaryDirectory
-
-
-# Monkey patch pip's Wheel class to support all platform tags. This allows
-# Prequ to generate hashes for all available distributions, not only the
-# one for the current platform.
-
-def _wheel_supported(self, tags=None):
-    # Ignore current platform. Support everything.
-    return True
-
-
-def _wheel_support_index_min(self, tags=None):
-    # All wheels are equal priority for sorting.
-    return 0
-
-
-Wheel.supported = _wheel_supported
-Wheel.support_index_min = _wheel_support_index_min
 
 
 class PyPIRepository(BaseRepository):


### PR DESCRIPTION
Commit 4900c7c4 introduced a feature which makes generate_hashes to
generate the hashes of all the available wheel packages for a
distribution.  Revert that feature, because it has two problems:

 1. Prequ is meant to compile the dependencies for just a single
    platform, the current one.  Hashes for any other platform shouldn't
    be in the generated txt file.

 2. It broke the PackageFinder so that the dependencies aren't resolved
    for the current platform, but for a magical "can install anything"
    platform and ended up generating incorrect dependency tree.  See the
    example below.

Here's an example that demonstrates why dependencies should be followed
for the current platform rather than accepting any wheel package:

Suppose you have "cryptography" in your source requirements and you're
compiling the requirements for Python 2.7.  The newest version of
cryptography is currently 2.0.3 which has wheels for Python 2 and 3.

The Python 3 wheel of cryptography==2.0.3 requires asn1crypto>=0.21.0,
cffi>=1.7, idna>=2.1 and six>=1.4.1, but the Python 2 wheel requires
asn1crypto>=0.21.0, cffi>=1.7, enum34, idna>=2.1, ipaddress and
six>=1.4.1.  If the Python 3 wheel is used to resolve the dependencies,
then enum34 or ipaddress will not be added to the dependency tree, since
they are not its dependencies.  Therefore it's essential to use the
Python 2 wheel when resolving dependencies for Python 2 platform,
otherwise the enum34 and ipaddress will not be pinned in the generated
txt file as they should.