### PR TITLE
Relative paths support

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,11 @@
 Unreleased
 ----------
 
+Features
+~~~~~~~~
+
+- Add support for unpinned non-editable VCS URLs
+
 General Changes
 ~~~~~~~~~~~~~~~
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -11,6 +11,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Ignore installed packages when calulating dependencies
+- Generate hashes of artifacts correctly
 
 1.2.2
 -----

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ General Changes
 ~~~~~~~~~~~~~~~
 
 - Make "via package" comments work for editable requirers too
+- Speedup: Do not regenerate hashes if they are already known
 
 1.2.2
 -----

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -5,6 +5,7 @@ Features
 ~~~~~~~~
 
 - Add support for unpinned non-editable VCS URLs
+- Make relative paths work as a requirement entry (editable or not)
 
 General Changes
 ~~~~~~~~~~~~~~~

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,11 @@
+Unreleased
+----------
+
+General Changes
+~~~~~~~~~~~~~~~
+
+- Make "via package" comments work for editable requirers too
+
 1.2.2
 -----
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,11 @@ General Changes
 - Make "via package" comments work for editable requirers too
 - Speedup: Do not regenerate hashes if they are already known
 
+Bug Fixes
+~~~~~~~~~
+
+- Ignore installed packages when calulating dependencies
+
 1.2.2
 -----
 

--- a/prequ/repositories/local.py
+++ b/prequ/repositories/local.py
@@ -2,7 +2,7 @@
 from __future__ import (
     absolute_import, division, print_function, unicode_literals)
 
-from prequ.utils import as_tuple, key_from_req, make_install_requirement
+from prequ.utils import as_tuple, key_from_ireq, make_install_requirement
 
 from .base import BaseRepository
 
@@ -49,7 +49,7 @@ class LocalRequirementsRepository(BaseRepository):
         self.repository.freshen_build_caches()
 
     def find_best_match(self, ireq, prereleases=None):
-        key = key_from_req(ireq.req)
+        key = key_from_ireq(ireq)
         existing_pin = self.existing_pins.get(key)
         if existing_pin and ireq_satisfied_by_existing_pin(ireq, existing_pin):
             project, version, _ = as_tuple(existing_pin)

--- a/prequ/repositories/local.py
+++ b/prequ/repositories/local.py
@@ -59,8 +59,8 @@ class LocalRequirementsRepository(BaseRepository):
         else:
             return self.repository.find_best_match(ireq, prereleases)
 
-    def get_dependencies(self, ireq):
-        return self.repository.get_dependencies(ireq)
+    def _get_dependencies(self, ireq):
+        return self.repository._get_dependencies(ireq)
 
     def get_hashes(self, ireq):
         check_is_hashable(ireq)

--- a/prequ/repositories/pypi.py
+++ b/prequ/repositories/pypi.py
@@ -14,8 +14,8 @@ from pip.req.req_set import RequirementSet
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound
 from ..utils import (
-    fs_str, is_pinned_requirement, is_vcs_link, lookup_table,
-    make_install_requirement, pip_version_info)
+    check_is_hashable, fs_str, is_pinned_requirement, is_vcs_link,
+    lookup_table, make_install_requirement, pip_version_info)
 from .base import BaseRepository
 
 try:
@@ -160,9 +160,7 @@ class PyPIRepository(BaseRepository):
         all of the files for a given requirement. It is not acceptable for an
         editable or unpinned requirement to be passed to this function.
         """
-        if not is_pinned_requirement(ireq):
-            raise TypeError(
-                "Expected pinned requirement, not unpinned or editable, got {}".format(ireq))
+        check_is_hashable(ireq)
 
         # We need to get all of the candidates that match our current version
         # pin, these will represent all of the files that could possibly

--- a/prequ/repositories/pypi.py
+++ b/prequ/repositories/pypi.py
@@ -165,6 +165,9 @@ class PyPIRepository(BaseRepository):
         """
         check_is_hashable(ireq)
 
+        if ireq.link and ireq.link.is_artifact:
+            return {self._get_file_hash(ireq.link)}
+
         # We need to get all of the candidates that match our current version
         # pin, these will represent all of the files that could possibly
         # satisify this constraint.

--- a/prequ/repositories/pypi.py
+++ b/prequ/repositories/pypi.py
@@ -145,7 +145,8 @@ class PyPIRepository(BaseRepository):
                                     self.source_dir,
                                     download_dir=download_dir,
                                     wheel_download_dir=self._wheel_download_dir,
-                                    session=self.session)
+                                    session=self.session,
+                                    ignore_installed=True)
             self._dependencies_cache[ireq] = reqset._prepare_file(self.finder, ireq)
         return set(self._dependencies_cache[ireq])
 

--- a/prequ/repositories/pypi.py
+++ b/prequ/repositories/pypi.py
@@ -14,8 +14,8 @@ from pip.req.req_set import RequirementSet
 from ..cache import CACHE_DIR
 from ..exceptions import NoCandidateFound
 from ..utils import (
-    check_is_hashable, fs_str, is_pinned_requirement, is_vcs_link,
-    lookup_table, make_install_requirement, pip_version_info)
+    check_is_hashable, fs_str, is_vcs_link, lookup_table,
+    make_install_requirement, pip_version_info)
 from .base import BaseRepository
 
 try:
@@ -125,15 +125,10 @@ class PyPIRepository(BaseRepository):
             best_candidate.project, best_candidate.version, ireq.extras, constraint=ireq.constraint
         )
 
-    def get_dependencies(self, ireq):
+    def _get_dependencies(self, ireq):
         """
-        Given a pinned or an editable InstallRequirement, returns a set of
-        dependencies (also InstallRequirements, but not necessarily pinned).
-        They indicate the secondary dependencies for the given requirement.
+        :type ireq: pip.req.InstallRequirement
         """
-        if not (ireq.editable or is_pinned_requirement(ireq)):
-            raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
-
         if ireq not in self._dependencies_cache:
             if ireq.link and not ireq.link.is_artifact:
                 # No download_dir for VCS sources.  This also works around pip

--- a/prequ/resolver.py
+++ b/prequ/resolver.py
@@ -281,11 +281,7 @@ class Resolver(object):
         Editable requirements will never be looked up, as they may have
         changed at any time.
         """
-        if ireq.editable:
-            for dependency in self.repository.get_dependencies(ireq):
-                yield dependency
-            return
-        elif not is_pinned_requirement(ireq):
+        if not is_pinned_requirement(ireq) and not ireq.editable:
             raise TypeError('Expected pinned or editable requirement, got {}'.format(ireq))
 
         # Now, either get the dependencies from the dependency cache (for
@@ -305,5 +301,4 @@ class Resolver(object):
             yield InstallRequirement.from_line(dependency_string, constraint=ireq.constraint)
 
     def reverse_dependencies(self, ireqs):
-        non_editable = [ireq for ireq in ireqs if not ireq.editable]
-        return self.dependency_cache.reverse_dependencies(non_editable)
+        return self.dependency_cache.reverse_dependencies(ireqs)

--- a/prequ/resolver.py
+++ b/prequ/resolver.py
@@ -11,7 +11,6 @@ import click
 from pip.req import InstallRequirement
 
 from .cache import DependencyCache
-from .exceptions import UnsupportedConstraint
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES, first, format_requirement, format_specifier, full_groupby,
@@ -138,11 +137,7 @@ class Resolver(object):
 
     @staticmethod
     def check_constraints(constraints):
-        for constraint in constraints:
-            if ((is_vcs_link(constraint) and not constraint.editable and
-                 not is_pinned_requirement(constraint))):
-                msg = 'Prequ does not support non-editable vcs URLs that are not pinned to one version.'
-                raise UnsupportedConstraint(msg, constraint)
+        pass
 
     def _group_constraints(self, constraints):
         """

--- a/prequ/resolver.py
+++ b/prequ/resolver.py
@@ -15,8 +15,7 @@ from .exceptions import UnsupportedConstraint
 from .logging import log
 from .utils import (
     UNSAFE_PACKAGES, first, format_requirement, format_specifier, full_groupby,
-    get_pinned_version, is_pinned_requirement, is_vcs_link, key_from_ireq,
-    key_from_req)
+    get_pinned_version, is_pinned_requirement, is_vcs_link, key_from_ireq)
 
 green = partial(click.style, fg='green')
 magenta = partial(click.style, fg='magenta')
@@ -28,7 +27,7 @@ class RequirementSummary(object):
     """
     def __init__(self, ireq):
         self.req = ireq.req
-        self.key = key_from_req(ireq.req)
+        self.key = key_from_ireq(ireq)
         self.extras = str(sorted(ireq.extras))
         self.specifier = str(ireq.specifier)
 
@@ -227,13 +226,13 @@ class Resolver(object):
         if has_changed:
             log.debug('')
             log.debug('New dependencies found in this round:')
-            for new_dependency in sorted(diff, key=lambda req: key_from_req(req.req)):
+            for new_dependency in sorted(diff, key=lambda ireq: key_from_ireq(ireq)):
                 log.debug('  adding {}'.format(new_dependency))
             log.debug('Removed dependencies in this round:')
-            for removed_dependency in sorted(removed, key=lambda req: key_from_req(req.req)):
+            for removed_dependency in sorted(removed, key=lambda ireq: key_from_ireq(ireq)):
                 log.debug('  removing {}'.format(removed_dependency))
             log.debug('Unsafe dependencies in this round:')
-            for unsafe_dependency in sorted(unsafe, key=lambda req: key_from_req(req.req)):
+            for unsafe_dependency in sorted(unsafe, key=lambda ireq: key_from_ireq(ireq)):
                 log.debug('  remembering unsafe {}'.format(unsafe_dependency))
 
         # Store the last round's results in the their_constraints

--- a/prequ/resolver.py
+++ b/prequ/resolver.py
@@ -59,6 +59,20 @@ class Resolver(object):
         self.clear_caches = clear_caches
         self.allow_unsafe = allow_unsafe
         self.unsafe_constraints = set()
+        self._prepare_ireqs(self.our_constraints)
+        self._prepare_ireqs(self.limiters)
+
+    def _prepare_ireqs(self, constraints):
+        """
+        Prepare install requirements for analysis.
+
+        :type constraints: Iterable[pip.req.InstallRequirement]
+        """
+        for constraint in constraints:
+            if constraint.link and not constraint.prepared:
+                os.environ[str('PIP_EXISTS_ACTION')] = str('i')
+                self.repository.prepare_ireq(constraint)
+                del os.environ[str('PIP_EXISTS_ACTION')]
 
     @property
     def constraints(self):

--- a/prequ/scripts/compile_in.py
+++ b/prequ/scripts/compile_in.py
@@ -16,7 +16,7 @@ from ..repositories import LocalRequirementsRepository
 from ..resolver import Resolver
 from ..utils import (
     UNSAFE_PACKAGES, assert_compatible_pip_version, dedup,
-    is_pinned_requirement, key_from_req)
+    is_pinned_requirement, key_from_ireq)
 from ..writer import OutputWriter
 from ._repo import get_pip_options_and_pypi_repository
 
@@ -121,10 +121,10 @@ def cli(verbose, silent, dry_run, pre, rebuild, find_links, index_url,
     if not upgrade and os.path.exists(dst_file):
         ireqs = parse_requirements(dst_file, finder=repository.finder, session=repository.session, options=pip_options)
         # Exclude packages from --upgrade-package/-P from the existing pins: We want to upgrade.
-        upgrade_pkgs_key = {key_from_req(InstallRequirement.from_line(pkg).req) for pkg in upgrade_packages}
-        existing_pins = {key_from_req(ireq.req): ireq
+        upgrade_pkgs_key = {key_from_ireq(InstallRequirement.from_line(pkg)) for pkg in upgrade_packages}
+        existing_pins = {key_from_ireq(ireq): ireq
                          for ireq in ireqs
-                         if is_pinned_requirement(ireq) and key_from_req(ireq.req) not in upgrade_pkgs_key}
+                         if is_pinned_requirement(ireq) and key_from_ireq(ireq) not in upgrade_pkgs_key}
         repository = LocalRequirementsRepository(existing_pins, repository)
 
     log.debug('Using indexes:')
@@ -225,8 +225,8 @@ def cli(verbose, silent, dry_run, pre, rebuild, find_links, index_url,
     writer.write(results=results,
                  unsafe_requirements=resolver.unsafe_constraints,
                  reverse_dependencies=reverse_dependencies,
-                 primary_packages={key_from_req(ireq.req) for ireq in constraints if not ireq.constraint},
-                 markers={key_from_req(ireq.req): ireq.markers
+                 primary_packages={key_from_ireq(ireq) for ireq in constraints if not ireq.constraint},
+                 markers={key_from_ireq(ireq): ireq.markers
                           for ireq in constraints if ireq.markers},
                  hashes=hashes,
                  allow_unsafe=allow_unsafe)

--- a/prequ/sync.py
+++ b/prequ/sync.py
@@ -4,6 +4,7 @@ import sys
 from subprocess import check_call
 
 import click
+from pip.download import url_to_path
 
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import (
@@ -168,7 +169,16 @@ def sync(to_install, to_uninstall,  # noqa: C901
 
 
 def _ireq_to_install_args(ireq):
+    """
+    :type ireq: pip.req.InstallRequirement
+    """
     if ireq.editable:
-        return ['-e', str(ireq.link or ireq.req)]
+        arg = str(ireq.link or ireq.req)
+        if ireq.link and ireq.link.url.startswith('file:'):
+            path = url_to_path(ireq.link.url)
+            if not os.path.isabs(path):
+                abspath = os.path.abspath(path)
+                arg = 'file://{}'.format(abspath.replace(os.path.sep, '/'))
+        return ['-e', arg]
     else:
         return [str(ireq.req)]

--- a/prequ/sync.py
+++ b/prequ/sync.py
@@ -4,7 +4,6 @@ import sys
 from subprocess import check_call
 
 import click
-from pip.download import url_to_path
 
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import (
@@ -172,13 +171,7 @@ def _ireq_to_install_args(ireq):
     """
     :type ireq: pip.req.InstallRequirement
     """
-    if ireq.editable:
-        arg = str(ireq.link or ireq.req)
-        if ireq.link and ireq.link.url.startswith('file:'):
-            path = url_to_path(ireq.link.url)
-            if not os.path.isabs(path):
-                abspath = os.path.abspath(path)
-                arg = 'file://{}'.format(abspath.replace(os.path.sep, '/'))
-        return ['-e', arg]
-    else:
-        return [str(ireq.req)]
+    line = format_requirement(ireq, root_dir=None)
+    if line.startswith('-e '):
+        return ['-e', line[3:]]
+    return [line]

--- a/prequ/sync.py
+++ b/prequ/sync.py
@@ -8,7 +8,7 @@ import click
 from .exceptions import IncompatibleRequirements, UnsupportedConstraint
 from .utils import (
     flat_map, format_requirement, is_pinned_requirement, is_vcs_link,
-    key_from_ireq, key_from_req)
+    key_from_dist, key_from_ireq, key_from_req)
 
 PACKAGES_TO_IGNORE = [
     'pip',
@@ -38,7 +38,7 @@ def dependency_tree(installed_keys, root_key):
 
     while queue:
         v = queue.popleft()
-        key = key_from_req(v)
+        key = key_from_dist(v)
         if key in dependencies:
             continue
 
@@ -65,7 +65,7 @@ def get_dists_to_ignore(installed):
     locally, click should also be installed/uninstalled depending on the given
     requirements.
     """
-    installed_keys = {key_from_req(r): r for r in installed}
+    installed_keys = {key_from_dist(r): r for r in installed}
     return list(flat_map(lambda req: dependency_tree(installed_keys, req), PACKAGES_TO_IGNORE))
 
 
@@ -77,7 +77,7 @@ def merge(requirements, ignore_conflicts):
             msg = 'Prequ does not support non-editable vcs URLs that are not pinned to one version.'
             raise UnsupportedConstraint(msg, ireq)
 
-        key = ireq.link or key_from_req(ireq.req)
+        key = key_from_ireq(ireq)
 
         if not ignore_conflicts:
             existing_ireq = by_key.get(key)
@@ -98,7 +98,7 @@ def diff(compiled_requirements, installed_dists):
     Calculate which packages should be installed or uninstalled, given a set
     of compiled requirements and a list of currently installed modules.
     """
-    requirements_lut = {r.link if r.editable else key_from_req(r.req): r for r in compiled_requirements}
+    requirements_lut = {key_from_ireq(r): r for r in compiled_requirements}
 
     satisfied = set()  # holds keys
     to_install = set()  # holds InstallRequirement objects
@@ -106,7 +106,7 @@ def diff(compiled_requirements, installed_dists):
 
     pkgs_to_ignore = get_dists_to_ignore(installed_dists)
     for dist in installed_dists:
-        key = key_from_req(dist)
+        key = key_from_dist(dist)
         if key not in requirements_lut:
             to_uninstall.add(key)
         elif requirements_lut[key].specifier.contains(dist.version):

--- a/prequ/utils.py
+++ b/prequ/utils.py
@@ -245,8 +245,6 @@ def as_tuple(ireq):
     """
     name = key_from_ireq(ireq)  # Runs also egg_info if needed
     version = get_ireq_version(ireq)
-    if not version:
-        raise TypeError('Not pinned: {!r}'.format(ireq))
     extras = tuple(sorted(ireq.extras))
     return name, version, extras
 

--- a/prequ/utils.py
+++ b/prequ/utils.py
@@ -108,6 +108,15 @@ def normalize_req_name(name):
 _REQUIREMENT_NORMALIZE_RX = re.compile(r'[-_.]+')
 
 
+def check_is_hashable(ireq):
+    if ireq.editable:
+        raise ValueError("Cannot hash editable requirement: {}".format(ireq))
+    if is_vcs_link(ireq):
+        raise ValueError("Cannot hash VCS link requirement: {}".format(ireq))
+    if not is_pinned_requirement(ireq):
+        raise ValueError("Cannot hash unpinned requirement: {}".format(ireq))
+
+
 def comment(text):
     return style(text, fg='green')
 

--- a/prequ/utils.py
+++ b/prequ/utils.py
@@ -134,17 +134,17 @@ def is_subdirectory(base, directory):
     return os.path.commonprefix([base, directory]) == base
 
 
-def format_requirement(ireq, marker=None):
+def format_requirement(ireq, marker=None, root_dir='.'):
     """
     Generic formatter for pretty printing InstallRequirements to the terminal
     in a less verbose way than using its `__str__` method.
     """
     if ireq.editable:
         path = ireq.link.path
-        if ireq.link.scheme == 'file' and is_subdirectory(os.getcwd(), path):
+        if ireq.link.scheme == 'file' and is_subdirectory(root_dir, path):
             # If the ireq.link is relative to the current directory then
             # output a relative path
-            relpath = os.path.relpath(path)
+            relpath = os.path.relpath(path, start=root_dir)
             path = '.' if relpath == '.' else os.path.join('.', relpath)
         else:
             path = ireq.link

--- a/prequ/utils.py
+++ b/prequ/utils.py
@@ -142,8 +142,10 @@ def format_requirement(ireq, marker=None):
     if ireq.editable:
         path = ireq.link.path
         if ireq.link.scheme == 'file' and is_subdirectory(os.getcwd(), path):
-            # If the ireq.link is relative to the current directory then output a relative path
-            path = 'file:' + os.path.join('.', os.path.relpath(path))
+            # If the ireq.link is relative to the current directory then
+            # output a relative path
+            relpath = os.path.relpath(path)
+            path = '.' if relpath == '.' else os.path.join('.', relpath)
         else:
             path = ireq.link
 

--- a/prequ/utils.py
+++ b/prequ/utils.py
@@ -240,12 +240,13 @@ def is_vcs_link(ireq):
 def as_tuple(ireq):
     """
     Pulls out the (name: str, version:str, extras:(str)) tuple from the pinned InstallRequirement.
-    """
-    if not is_pinned_requirement(ireq):
-        raise TypeError('Expected a pinned InstallRequirement, got {}'.format(ireq))
 
-    name = key_from_ireq(ireq)
-    version = first(ireq.specifier._specs)._spec[1]
+    :type ireq: InstallRequirement
+    """
+    name = key_from_ireq(ireq)  # Runs also egg_info if needed
+    version = get_ireq_version(ireq)
+    if not version:
+        raise TypeError('Not pinned: {!r}'.format(ireq))
     extras = tuple(sorted(ireq.extras))
     return name, version, extras
 

--- a/prequ/writer.py
+++ b/prequ/writer.py
@@ -7,7 +7,8 @@ from ._compat import ExitStack
 from .file_replacer import FileReplacer
 from .logging import log
 from .utils import (
-    UNSAFE_PACKAGES, comment, dedup, format_requirement, key_from_ireq)
+    UNSAFE_PACKAGES, comment, dedup, format_requirement, formatted_as,
+    key_from_ireq)
 
 
 class OutputWriter(object):
@@ -31,7 +32,9 @@ class OutputWriter(object):
         self.silent = silent
 
     def _sort_key(self, ireq):
-        return key_from_ireq(ireq)
+        line_format = formatted_as(ireq, self.find_links)
+        section_num = {'path': 0}.get(line_format, 9)
+        return (section_num, key_from_ireq(ireq))
 
     def write_header(self):
         if self.emit_header:
@@ -132,8 +135,11 @@ class OutputWriter(object):
                     f.write(os.linesep.encode('utf-8'))
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
-        dst_dir = os.path.dirname(self.dst_file)
-        line = format_requirement(ireq, marker=marker, root_dir=dst_dir)
+        line = format_requirement(
+            ireq,
+            marker=marker,
+            root_dir=os.path.dirname(self.dst_file),
+            find_links_dirs=self.find_links)
 
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
         if ireq_hashes:

--- a/prequ/writer.py
+++ b/prequ/writer.py
@@ -132,7 +132,8 @@ class OutputWriter(object):
                     f.write(os.linesep.encode('utf-8'))
 
     def _format_requirement(self, ireq, reverse_dependencies, primary_packages, marker=None, hashes=None):
-        line = format_requirement(ireq, marker=marker)
+        dst_dir = os.path.dirname(self.dst_file)
+        line = format_requirement(ireq, marker=marker, root_dir=dst_dir)
 
         ireq_hashes = (hashes if hashes is not None else {}).get(ireq)
         if ireq_hashes:

--- a/prequ/writer.py
+++ b/prequ/writer.py
@@ -7,7 +7,7 @@ from ._compat import ExitStack
 from .file_replacer import FileReplacer
 from .logging import log
 from .utils import (
-    UNSAFE_PACKAGES, comment, dedup, format_requirement, key_from_req)
+    UNSAFE_PACKAGES, comment, dedup, format_requirement, key_from_ireq)
 
 
 class OutputWriter(object):
@@ -31,7 +31,7 @@ class OutputWriter(object):
         self.silent = silent
 
     def _sort_key(self, ireq):
-        return key_from_req(ireq.req) if ireq.req else u'{}'.format(ireq)
+        return key_from_ireq(ireq)
 
     def write_header(self):
         if self.emit_header:
@@ -97,7 +97,7 @@ class OutputWriter(object):
         for ireq in packages:
             line = self._format_requirement(
                 ireq, reverse_dependencies, primary_packages,
-                markers.get(key_from_req(ireq.req)), hashes=hashes)
+                markers.get(key_from_ireq(ireq)), hashes=hashes)
             yield line
 
         if unsafe_requirements:
@@ -109,7 +109,7 @@ class OutputWriter(object):
                 req = self._format_requirement(ireq,
                                                reverse_dependencies,
                                                primary_packages,
-                                               marker=markers.get(key_from_req(ireq.req)),
+                                               marker=markers.get(key_from_ireq(ireq)),
                                                hashes=hashes)
                 if not allow_unsafe:
                     yield comment('# {}'.format(req))
@@ -139,7 +139,7 @@ class OutputWriter(object):
             for hash_ in sorted(ireq_hashes):
                 line += " \\\n    --hash={}".format(hash_)
 
-        if not self.annotate or key_from_req(ireq.req) in primary_packages:
+        if not self.annotate or key_from_ireq(ireq) in primary_packages:
             return line
 
         # Annotate what packages this package is required by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ class FakeRepository(BaseRepository):
         best_version = max(versions, key=Version)
         return make_install_requirement(key_from_ireq(ireq), best_version, ireq.extras, constraint=ireq.constraint)
 
-    def get_dependencies(self, ireq):
+    def _get_dependencies(self, ireq):
         if ireq.editable:
             return self.editables[str(ireq.link)]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,7 +250,7 @@ def test_editable_package_vcs(tmpdir):
     vcs_package = (
         'git+git://github.com/pytest-dev/pytest-django'
         '@21492afc88a19d4ca01cd0ac392a5325b14f95c7'
-        '#egg=pytest-django==3.1.3.dev32+g21492af'
+        '#egg=pytest-django'
     )
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,7 +250,7 @@ def test_editable_package_vcs(tmpdir):
     vcs_package = (
         'git+git://github.com/pytest-dev/pytest-django'
         '@21492afc88a19d4ca01cd0ac392a5325b14f95c7'
-        '#egg=pytest-django'
+        '#egg=pytest-django==3.1.3.dev32+g21492af'
     )
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,7 +271,7 @@ def test_relative_editable_package(small_fake_package_dir):
         # Move the small_fake_package inside the temp directory
         shutil.copytree(small_fake_package_dir, new_package_dir)
         relative_package_dir = os.path.relpath(new_package_dir)
-        relative_package_req = '-e file:' + os.path.join('.', relative_package_dir)
+        relative_package_req = '-e ' + os.path.join('.', relative_package_dir)
 
         with open('requirements.in', 'w') as req_in:
             req_in.write('-e ' + 'small_fake_package')  # require editable fake package

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,8 @@ from six.moves.urllib.request import pathname2url
 from prequ.scripts.compile_in import cli
 from prequ.scripts.sync import cli as sync_cli
 
+from .utils import check_successful_exit
+
 
 @pytest.yield_fixture
 def pip_conf(tmpdir):
@@ -168,7 +170,7 @@ def test_realistic_complex_sub_dependencies(tmpdir):
                                   '-n', '--rebuild',
                                   '-f', str(tmpdir)])
 
-        assert out.exit_code == 0
+        check_successful_exit(out)
 
 
 def _invoke(command):
@@ -225,7 +227,7 @@ def test_sync_quiet(tmpdir):
         with mock.patch('prequ.sync.check_call') as check_call:
             out = runner.invoke(sync_cli, ['-q'])
             assert out.output == ''
-            assert out.exit_code == 0
+            check_successful_exit(out)
             # for every call to pip ensure the `-q` flag is set
             for call in check_call.call_args_list:
                 assert '-q' in call[0][0]
@@ -241,7 +243,7 @@ def test_editable_package(small_fake_package_dir):
 
         out = runner.invoke(cli, ['-n'])
 
-        assert out.exit_code == 0
+        check_successful_exit(out)
         assert small_fake_package_dir in out.output
         assert 'six==1.10.0' in out.output
 
@@ -258,7 +260,7 @@ def test_editable_package_vcs(tmpdir):
             req_in.write('-e ' + vcs_package)
         out = runner.invoke(cli, ['-n',
                                   '--rebuild'])
-        assert out.exit_code == 0
+        check_successful_exit(out)
         assert vcs_package in out.output
         assert 'pytest' in out.output  # dependency of pytest-django
 
@@ -279,7 +281,7 @@ def test_relative_editable_package(small_fake_package_dir):
         out = runner.invoke(cli, ['-n'])
 
         print(out.output)
-        assert out.exit_code == 0
+        check_successful_exit(out)
         assert relative_package_req in out.output
 
 
@@ -295,7 +297,7 @@ def test_input_file_without_extension():
 
         out = runner.invoke(cli, ['requirements'])
 
-        assert out.exit_code == 0
+        check_successful_exit(out)
         assert os.path.exists('requirements.txt')
         assert 'six==1.10.0' in open('requirements.txt').read()
 
@@ -316,6 +318,6 @@ def test_upgrade_packages_option(minimal_wheels_dir):
             '-f', minimal_wheels_dir,
         ])
 
-        assert out.exit_code == 0
+        check_successful_exit(out)
         assert 'small-fake-a==0.1' in out.output
         assert 'small-fake-b==0.2' in out.output

--- a/tests/test_prequ_check.py
+++ b/tests/test_prequ_check.py
@@ -6,7 +6,7 @@ from pip.exceptions import DistributionNotFound
 from prequ.scripts.check import main as check_main
 
 from .dirs import FAKE_PYPI_WHEELS_DIR
-from .utils import make_cli_runner
+from .utils import check_successful_exit, make_cli_runner
 
 run_check = make_cli_runner(check_main, [])
 
@@ -31,7 +31,7 @@ TXT_CONTENTS = {
 def test_simple_case(pip_conf, txt_status, mode):
     out = run_check(pip_conf, TXT_CONTENTS[txt_status], mode)
     if txt_status == 'up_to_date':
-        assert out.exit_code == 0
+        check_successful_exit(out)
         if mode in ('default', 'verbose'):
             expected_output = 'requirements.txt is OK\n'
         elif mode == 'silent':

--- a/tests/test_prequ_update.py
+++ b/tests/test_prequ_update.py
@@ -12,7 +12,7 @@ from prequ.configuration import (
 from prequ.scripts.update import main as update_main
 
 from .dirs import FAKE_PYPI_WHEELS_DIR
-from .utils import make_cli_runner
+from .utils import check_successful_exit, make_cli_runner
 
 run_check = make_cli_runner(update_main, ['-v'])
 
@@ -72,7 +72,7 @@ def test_invalid_option(pip_conf):
 def test_umlaut_in_prequ_conf_file(pip_conf):
     options = {'wheel_sources': {'mämmi': 'http://localhost/mämmi'}}
     with run_check(pip_conf, options) as out:
-        assert out.exit_code == 0
+        check_successful_exit(out)
 
 
 def test_detect_annotate(pip_conf):
@@ -138,7 +138,7 @@ def run_detection_check(pip_conf, req_txt_content, extra_options=None):
     if req_txt_content is not None:
         conf['existing_out_files'] = {'requirements.txt': req_txt_content}
     with run_check(pip_conf, **conf) as out:
-        assert out.exit_code == 0
+        check_successful_exit(out)
         return _read_text_file('requirements.txt')
 
 
@@ -154,7 +154,7 @@ def test_conf_merging(pip_conf):
     }
     txt_prelude = HEADER + '--trusted-host localhost\n\n'
     with run_check(pip_conf, **conf) as result:
-        assert result.exit_code == 0
+        check_successful_exit(result)
         assert 'small-fake-a' in result.output
         assert 'small-fake-b' in result.output
         assert 'tiny-depender' not in result.output
@@ -176,7 +176,7 @@ def test_only_in_files(pip_conf_with_wheeldir):
     }
     txt_prelude = HEADER + '--trusted-host localhost\n\n'
     with run_check(pip_conf_with_wheeldir, **conf) as result:
-        assert result.exit_code == 0
+        check_successful_exit(result)
         assert 'small-fake-a' in result.output
         assert 'small-fake-b' in result.output
         assert _read_text_file('requirements.txt') == (

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -30,6 +30,9 @@ def test_pypirepo_calls_reqset_with_str_paths():
         mocked_reqset = MagicMock()
         mocked_init.return_value = mocked_reqset
 
+        # Fill link for ireq, because get_dependencies uses it as a cache key
+        ireq.link = MagicMock(url='http://localhost/ansible2400.zip')
+
         # Do the call
         repo.get_dependencies(ireq)
 

--- a/tests/test_repository_pypi.py
+++ b/tests/test_repository_pypi.py
@@ -95,7 +95,7 @@ def test_generate_hashes_without_interfering_with_each_other(from_line):
 
 def test_get_hashes_non_pinned(from_line):
     repository = get_repository()
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         repository.get_hashes(from_line('prequ'))
 
 

--- a/tests/test_top_level_editable.py
+++ b/tests/test_top_level_editable.py
@@ -7,13 +7,13 @@ from prequ.scripts._repo import get_pip_command
 
 
 class MockedPyPIRepository(PyPIRepository):
-    def get_dependencies(self, ireq):
+    def _get_dependencies(self, ireq):
         # "mock" everything but editable reqs to avoid disk and network I/O
         # when possible
         if not ireq.editable:
             return set()
 
-        return super(MockedPyPIRepository, self).get_dependencies(ireq)
+        return super(MockedPyPIRepository, self)._get_dependencies(ireq)
 
 
 def _get_repository():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_format_requirement_non_relative_editable(from_editable, small_fake_pack
 
 def test_format_requirement_relative_editable(from_editable, small_fake_package_dir):
     ireq = from_editable(small_fake_package_dir)
-    assert format_requirement(ireq) == '-e file:./tests/fake_pypi/small_fake_package'
+    assert format_requirement(ireq) == '-e ./tests/fake_pypi/small_fake_package'
 
 
 def test_format_specifier(from_line):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 
+from pip.download import path_to_url
+
 from prequ.utils import (
     as_tuple, dedup, flat_map, format_requirement, format_specifier,
     is_subdirectory)
@@ -30,12 +32,13 @@ def test_format_requirement_non_relative_editable(from_editable, small_fake_pack
     tmp_package_dir = os.path.join(str(tmpdir), 'small_fake_package')
     shutil.copytree(small_fake_package_dir, tmp_package_dir)
     ireq = from_editable(tmp_package_dir)
-    assert format_requirement(ireq) == '-e file://' + tmp_package_dir
+    assert format_requirement(ireq) == '-e ' + path_to_url(tmp_package_dir)
 
 
 def test_format_requirement_relative_editable(from_editable, small_fake_package_dir):
     ireq = from_editable(small_fake_package_dir)
-    assert format_requirement(ireq) == '-e ./tests/fake_pypi/small_fake_package'
+    assert format_requirement(ireq, root_dir='.') == (
+        '-e ./tests/fake_pypi/small_fake_package')
 
 
 def test_format_specifier(from_line):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
 import os
 import shutil
 
-from pytest import raises
-
 from prequ.utils import (
     as_tuple, dedup, flat_map, format_requirement, format_specifier,
     is_subdirectory)
@@ -66,16 +64,15 @@ def test_as_tuple(from_line):
     assert version == '1.1'
     assert extras == ("extra1", "extra2")
 
-    # Non-pinned versions aren't accepted
-    should_be_rejected = [
+    # Non-pinned versions return None as version
+    non_pinneds = [
         'foo==1.*',
         'foo~=1.1,<1.5,>1.2',
         'foo',
     ]
-    for spec in should_be_rejected:
+    for spec in non_pinneds:
         ireq = from_line(spec)
-        with raises(TypeError):
-            as_tuple(ireq)
+        assert as_tuple(ireq)[1] is None
 
 
 def test_flat_map():

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -20,7 +20,9 @@ def writer():
 
 def test_format_requirements_relative_path(from_editable, writer):
     ireq = from_editable('file:fake_pypi/fake_package#egg=fake_package')
-    assert writer._format_requirement(ireq, {}, primary_packages=['fake_package']) == '-e file:./fake_pypi/fake_package'
+    assert writer._format_requirement(
+        ireq, {}, primary_packages=['fake_package']) == (
+        '-e ./fake_pypi/fake_package')
 
 
 def test_format_requirement_annotation_editable(from_editable, writer):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,12 +27,21 @@ def make_cli_runner(cli_function, cli_args):
         with runner.isolated_filesystem():
             create_configuration(options, requirements, **extra_conf)
             out = runner.invoke(cli_function, cli_args)
-            if out.exit_code == -1:
-                (exc_type, exc_value, traceback) = out.exc_info
-                exc_value.run_result = out
-                six.reraise(exc_type, exc_value, traceback)
+            _reraise_if_excepted(out)
             yield out
     return run_check
+
+
+def check_successful_exit(run_result):
+    _reraise_if_excepted(run_result)
+    assert run_result.exit_code == 0
+
+
+def _reraise_if_excepted(run_result):
+    if run_result.exit_code == -1:
+        (exc_type, exc_value, traceback) = run_result.exc_info
+        exc_value.run_result = run_result
+        six.reraise(exc_type, exc_value, traceback)
 
 
 def create_configuration(options=None, requirements=None,


### PR DESCRIPTION
Implement support for relative paths in the source requirements.  Any
relative paths will be compiled as relative paths to the output file
too.  They can be editable or non-editable.

There is also other related fixes and improvements, which are required
for this feature.

Implements #2