### PR TITLE
Add support for Pip 18

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,12 +4,15 @@ environment:
     - TOXENV: py27-pip8
     - TOXENV: py27-pip9
     - TOXENV: py27-pip10
+    - TOXENV: py27-pip18
     - TOXENV: py34-pip8
     - TOXENV: py34-pip9
     - TOXENV: py34-pip10
+    - TOXENV: py34-pip18
     - TOXENV: py35-pip9
     - TOXENV: py36-pip9
     - TOXENV: py36-pip10
+    - TOXENV: py36-pip18
     - TOXENV: py36-pipmaster
 install:
   - python -m pip install -U pip setuptools wheel

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,11 @@
 Prequ Change Log
 ================
 
+General Changes
+~~~~~~~~~~~~~~~
+
+- Add support for Pip 18
+
 1.4.1
 -----
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = style,packaging,py{27,34,35,36,py}-pip{8,9,10,master}
+envlist = style,packaging,py{27,34,35,36,py}-pip{8,9,10,18,master}
 
 [testenv]
 deps =
     pip8: pip~=8.0.0
     pip9: pip~=9.0
     pip10: pip~=10.0
+    pip18: pip~=18.0
     pipmaster: git+https://github.com/pypa/pip.git@master
     -rrequirements-test.txt
 setenv =


### PR DESCRIPTION
In the Pip 18 release there was some internal API changes that we rely on so our usage of them (in the PyPIRepository) must me amended.  Do that and update the test matrix to include also Pip 18.